### PR TITLE
Adds dedicated release workflow

### DIFF
--- a/.github/workflows/DockerPublish.yml
+++ b/.github/workflows/DockerPublish.yml
@@ -1,21 +1,15 @@
-name: Publish Docker Images
+name: Publish Docker Image
 
 on:
-  release:
-    types: [ "released" ]
+  workflow_call:
 
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/fig-tree
 
 jobs:
-  test:
-    name: Test
-    uses: ./.github/workflows/PackageTest.yml
-
   publish-docker:
     runs-on: ubuntu-latest
-    name: Publish Docker Image
-    needs: [ test ]
+    name: Publish Image
 
     steps:
       - name: Checkout source
@@ -50,10 +44,3 @@ jobs:
         with:
           push: true
           tags: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }},${{ env.IMAGE_NAME }}:latest
-
-  publish-docs:
-    name: Docs
-    needs: [ publish-docker ]
-    uses: ./.github/workflows/DocumentationPublish.yml
-    with:
-      version: ${{ github.event.release.tag_name }}

--- a/.github/workflows/DocumentationPublish.yml
+++ b/.github/workflows/DocumentationPublish.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   publish:
-    name: Publish
+    name: Publish HTML
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,26 @@
+name: Publish Project Release
+
+on:
+  release:
+    types: [ "released" ]
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/fig-tree
+
+jobs:
+  test:
+    name: Test
+    uses: ./.github/workflows/PackageTest.yml
+
+  publish-docker:
+    name: Docker
+    needs: [ test ]
+    uses: ./.github/workflows/DockerPublish.yml
+
+  publish-docs:
+    name: Docs
+    needs: [ publish-docker ]
+    uses: ./.github/workflows/DocumentationPublish.yml
+    with:
+      version: ${{ github.event.release.tag_name }}
+      latest: true


### PR DESCRIPTION
After tagging the first release (`0.1.0`) I reviewed the CI log and decided to make some improvements for clarity's sake. Having a dedicated "Release.yml" workflow helps keep the publication CI clean and easy to understand.